### PR TITLE
feat(Clock): Exposed `.restart` return value as `_Time`

### DIFF
--- a/lib/clock.d.ts
+++ b/lib/clock.d.ts
@@ -4,5 +4,5 @@ export class Clock {
   constructor();
 
   getElapsedTime(): _Time;
-  restart(): void;
+  restart(): _Time;
 }

--- a/src/clock.cc
+++ b/src/clock.cc
@@ -52,7 +52,16 @@ NAN_METHOD(Clock::GetElapsedTime) {
 
 NAN_METHOD(Clock::Restart) {
   Clock* clock = Nan::ObjectWrap::Unwrap<Clock>(info.Holder());
-  clock->_clock.restart();
+  sf::Time time = clock->_clock.restart();
+  Nan::TryCatch try_catch;
+  MaybeLocal<Object> time_wrap =
+      time::Time::NewInstance(info.GetIsolate(), time);
+  if (time_wrap.IsEmpty()) {
+    try_catch.ReThrow();
+    return;
+  }
+
+  info.GetReturnValue().Set(time_wrap.ToLocalChecked());
 }
 
 Clock::Clock() : _clock() {}


### PR DESCRIPTION
As of https://www.sfml-dev.org/documentation/2.5.1/Clock_8hpp_source.php#l00074 and https://github.com/SFML/SFML/blob/2.5.x/src/SFML/System/Clock.cpp#L54

`Clock.restart` should have immediate elapsed time in return after calling the function.
This benefits implementation that utilize `Clock.restart` directly without using both `Clock.getElapsedTime` then `Clock.restart`

Any response is happily welcomed!